### PR TITLE
Update deps & more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_install:
   - npm install -g npm@~1.4.6

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var argv = require('minimist')(process.argv.slice(2));
+var argv = require('subarg')(process.argv.slice(2));
 var JSONStream = require('JSONStream');
 
 var sort = require('../')(argv);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "deps-sort": "bin/cmd.js"
   },
   "dependencies": {
-    "JSONStream": "~0.8.4",
+    "JSONStream": "~0.10.0",
     "isarray": "0.0.1",
     "minimist": "~0.2.0",
     "shasum": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "JSONStream": "~0.10.0",
     "isarray": "0.0.1",
-    "minimist": "~0.2.0",
     "shasum": "^1.0.0",
+    "subarg": "^1.0.0",
     "through2": "~0.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "through2": "~0.5.1"
   },
   "devDependencies": {
-    "tape": "^2.13.4"
+    "tape": "^4.0.0"
   },
   "scripts": {
     "test": "tape test/*.js"


### PR DESCRIPTION
* Sync's travis node versions with browserify
* Switch to subarg from minimist
  * Why since subarg uses minimst? Well, so that it dedupes with browserify's subarg - since browserify is most likely the consumer of this module :P
* Update JSONStream to ~0.10.0
  * This part of https://github.com/substack/node-browserify/issues/707#issuecomment-96273418. Unfortunately we can't update to JSONStream@^1.0.1 (see https://github.com/dominictarr/JSONStream/pull/67), so ~0.10.0 will have to do.