### PR TITLE
Change to latest jsonstream version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "isarray": "0.0.1",
-    "jsonstream": "^1.0.3",
+    "jsonstream": "^0.10.0",
     "shasum": "^1.0.0",
     "subarg": "^1.0.0",
     "through2": "~0.5.1"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "isarray": "0.0.1",
-    "jsonstream": "^0.10.0",
+    "JSONstream": "^0.10.0",
     "shasum": "^1.0.0",
     "subarg": "^1.0.0",
     "through2": "~0.5.1"


### PR DESCRIPTION
Had to bump back the jsonstream version because 1.0.3 doesn't exist yet and version 1 isn't available on npm yet.