### PR TITLE
support sha1 index

### DIFF
--- a/test/sha1Indexed.js
+++ b/test/sha1Indexed.js
@@ -1,0 +1,46 @@
+var sort = require('../');
+var test = require('tap').test;
+var through = require('through2');
+var shasum = require('shasum');
+
+test('sha1 indexed', function (t) {
+    t.plan(1);
+    var s = sort({ index: 'sha1' });
+    var rows = [];
+    function write (row, enc, next) { rows.push(row); next() }
+    function end () {
+        t.deepEqual(rows, [
+            {
+                id: '/bar.js',
+                deps: {},
+                index: index('THREE'),
+                indexDeps: {},
+                source: 'THREE'
+            },
+            {
+                id: '/foo.js',
+                deps: { './bar': '/bar.js' },
+                index: index('TWO'),
+                indexDeps: { './bar': index('THREE') },
+                source: 'TWO'
+            },
+            {
+                id: '/main.js',
+                deps: { './foo': '/foo.js' },
+                index: index('ONE'),
+                indexDeps: { './foo': index('TWO') },
+                source: 'ONE'
+            },
+        ]);
+    }
+    s.pipe(through.obj(write, end));
+
+    s.write({ id: '/main.js', deps: { './foo': '/foo.js' }, source: 'ONE' });
+    s.write({ id: '/foo.js', deps: { './bar': '/bar.js' }, source: 'TWO' });
+    s.write({ id: '/bar.js', deps: {}, source: 'THREE' });
+    s.end();
+});
+
+function index(s) {
+    return shasum(s).slice(0, 7);
+}


### PR DESCRIPTION
I run into a problem when using browserify with factor-bundle. 

Suppose `a.js` depends on `base.js`, and we build `a.js` to `page.js`, `base.js` to `common.js`.
Then `a.js` will get `id` `1`, `base.js` `2`. 
However, if I add a new `b.js` (`require('b.js')`) to `a.js`, which still built to `page.js`, `base.js` wil get `id` `3`, and  the contents of `common.js` has changed! This will invalidate the browser cache.

I created some example [here](https://github.com/zoubin/deps-sort-integer-index-problem)

I think the `integer index` is behind this, and a `sha1 index` will resolve it. I am not quite sure if it is the proper way. 